### PR TITLE
Explicitly use JVM 8 on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
     - uses: actions/checkout@v3
     - uses: coursier/cache-action@v6
     - uses: coursier/setup-action@v1.3.0
+      with:
+        jvm: 8
     - name: Compile
       run: sbtn test:compile
 
@@ -25,6 +27,8 @@ jobs:
     - uses: actions/checkout@v3
     - uses: coursier/cache-action@v6
     - uses: coursier/setup-action@v1.3.0
+      with:
+        jvm: 8
     - uses: olafurpg/setup-gpg@v3
     - name: Release
       run: sbtn ci-release

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target/
 .bsp/
+.metals/
+.vscode/

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,1 @@
+updates.ignore = [ { groupId = "org.graalvm.nativeimage", artifactId = "svm" } ]

--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ lazy val `jni-graalvm` = project
     licenses := List("GPL-2.0" -> url("https://opensource.org/licenses/GPL-2.0")),
     name := "windows-ansi-graalvm",
     libraryDependencies ++= Seq(
-      "org.graalvm.nativeimage" % "svm" % "22.3.0" % Provided
+      "org.graalvm.nativeimage" % "svm" % "22.0.0.2" % Provided
     )
   )
 


### PR DESCRIPTION
Not sure why, it seems the `0.0.4` artifacts require Java 11:
```text
$ javap -v -cp "$(cs fetch io.github.alexarchambault.windows-ansi:windows-ansi:0.0.4 --classpath)" \ 
    io.github.alexarchambault.windowsansi.WindowsAnsi \
      | grep "major version:"
  major version: 55
```