### PR TITLE
Update Jansi to 2.4.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ lazy val jni = project
     shared,
     name := "windows-ansi",
     libraryDependencies ++= Seq(
-      "org.fusesource.jansi" % "jansi" % "1.18"
+      "org.fusesource.jansi" % "jansi" % "2.4.1",
     )
   )
 

--- a/jni/src/main/java/io/github/alexarchambault/windowsansi/WindowsAnsi.java
+++ b/jni/src/main/java/io/github/alexarchambault/windowsansi/WindowsAnsi.java
@@ -3,11 +3,24 @@ package io.github.alexarchambault.windowsansi;
 import org.fusesource.jansi.internal.Kernel32;
 
 import java.io.IOException;
+import java.net.URL;
+import java.util.Locale;
 import java.util.Objects;
 
 public final class WindowsAnsi {
 
     static {
+        // Workaround while we can't benefit from https://github.com/fusesource/jansi/pull/292
+        String arch = System.getProperty("os.arch", "").toLowerCase(Locale.ROOT);
+        if (arch.equals("arm64") || arch.equals("aarch64")) {
+            ClassLoader cl = Thread.currentThread().getContextClassLoader();
+            URL dllUrl = cl.getResource("org/fusesource/jansi/internal/native/Windows/arm64/jansi.dll");
+            URL soUrl = cl.getResource("org/fusesource/jansi/internal/native/Windows/arm64/libjansi.so");
+            if (dllUrl == null && soUrl != null) {
+                System.setProperty("library.jansi.name", "libjansi.so");
+            }
+        }
+
         // Make https://github.com/fusesource/hawtjni/blob/c14fec00b9976ff6b84e62e483d678594a7d3832/hawtjni-runtime/src/main/java/org/fusesource/hawtjni/runtime/Library.java#L167 happy
         if (System.getProperty("com.ibm.vm.bitmode") == null)
             System.setProperty("com.ibm.vm.bitmode", "64");

--- a/jni/src/main/java/io/github/alexarchambault/windowsansi/WindowsAnsi.java
+++ b/jni/src/main/java/io/github/alexarchambault/windowsansi/WindowsAnsi.java
@@ -1,7 +1,6 @@
 package io.github.alexarchambault.windowsansi;
 
 import org.fusesource.jansi.internal.Kernel32;
-import org.fusesource.jansi.internal.WindowsSupport;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -31,7 +30,7 @@ public final class WindowsAnsi {
         long console = Kernel32.GetStdHandle(Kernel32.STD_OUTPUT_HANDLE);
         int[] mode = new int[1];
         if (Kernel32.GetConsoleMode(console, mode) == 0)
-            throw new IOException("Failed to get console mode: " + WindowsSupport.getLastErrorMessage());
+            throw new IOException("Failed to get console mode: " + Kernel32.getLastErrorMessage());
         return Kernel32.SetConsoleMode(console, mode[0] | ENABLE_VIRTUAL_TERMINAL_PROCESSING) != 0;
     }
 


### PR DESCRIPTION
Jansi 2.4.1 added [support for Windows ARM](https://github.com/fusesource/jansi/issues/238).

Closes https://github.com/coursier/coursier/issues/2175